### PR TITLE
Remove unused function

### DIFF
--- a/scripting/convar_configs.sp
+++ b/scripting/convar_configs.sp
@@ -110,15 +110,6 @@ void Config_LockConVar(ConVar convar, const char[] value) {
 	convar.AddChangeHook(OnConVarChanged);
 }
 
-void Config_UnlockConVar(ConVar convar) {
-	char convarName[MAX_CONVAR_NAME_LENGTH];
-	convar.GetName(convarName, sizeof(convarName));
-	
-	g_LockedConVars.Remove(convarName);
-	
-	convar.RemoveChangeHook(OnConVarChanged);
-}
-
 void Config_SetConVarFlagState(ConVar convar, int flag, const char[] value) {
 	bool bEnable = StringToInt(value) != 0;
 	if (bEnable) {


### PR DESCRIPTION
The `Config_UnlockConVar` function exists but was never used in the script. This will make the build clean and free of warnings when compiling.